### PR TITLE
更新manual/plugins/index.md

### DIFF
--- a/manual/plugins/index.md
+++ b/manual/plugins/index.md
@@ -10,7 +10,7 @@
     <p>我们现有的插件列表已经可以在插件展示网站上查看。</p>
     <div class="website-links">
       <a href="https://plugins.maibot.chat" class="backup-link" target="_blank">
-        <span class="link-text">备用：plugins.maibot.chat</span>
+        <span class="link-text">plugins.maibot.chat</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
删除了无法使用的插件库主站

## Sourcery 总结

移除 `manual/plugins/index.md` 文档中过时的插件仓库链接并简化备份链接文本。

文档：
- 移除指向 `maim-with-u.github.io/plugin-repo` 的不可用的主要插件站点链接
- 简化备份链接文本，使其只显示 `plugins.maibot.chat`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove outdated plugin repository link and simplify backup link text in the manual/plugins/index.md documentation.

Documentation:
- Remove the unusable primary plugin site link to maim-with-u.github.io/plugin-repo
- Simplify the backup link text to only display plugins.maibot.chat

</details>