### PR TITLE
talk_value值感觉写反了，应该越高话越少吧？至少测试结果是这样

### DIFF
--- a/manual/usage/features/chat.md
+++ b/manual/usage/features/chat.md
@@ -21,7 +21,7 @@
 
 - 新消息较少
 - planner决定选择no_reply：可以修改配置文件中的plan_style和interest，此配置会明显影响麦麦的回复和其他动作行为
-- talk_value较低
+- talk_value较高
 
 ```toml
 


### PR DESCRIPTION
## Sourcery 总结

文档：
- 修正了 chat.md 中 talk_value 从“较低”到“较高”的颠倒描述，以符合测试结果和实际行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix inverted description of talk_value from "lower" to "higher" in chat.md to align with test results and actual behavior.

</details>