### PR TITLE
更新telegram adapter链接

### DIFF
--- a/manual/adapters/index.md
+++ b/manual/adapters/index.md
@@ -14,7 +14,7 @@
 - [桌宠 适配器](https://github.com/MaiM-with-u/MaiM-desktop-pet)
 - [微信 - wxauto Adapter](https://github.com/aki66938/WeMai?tab=readme-ov-file)
 - [Discord](https://github.com/2829798842/MaiBot-Discord-Adapter)
-- [Telegram](https://github.com/MaiM-with-u/maibot-telegram-adapter)
+- [Telegram](https://github.com/xiaoxi68/MaiBot-Telegram-Adapter)
 - 微信 - Adapter
 - [Milky协议 适配器](https://github.com/ShinKanji/MaiBot-Milky-Adapter)
 


### PR DESCRIPTION
更新telegram adapter链接

## Sourcery 总结

文档:
- 修正 manual/adapters 索引中 Telegram 适配器的 GitHub URL

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the GitHub URL for the Telegram adapter in the manual/adapters index

</details>