### PR TITLE
Update mmc_deploy_android.md

### DIFF
--- a/manual/deployment/community/mmc_deploy_android.md
+++ b/manual/deployment/community/mmc_deploy_android.md
@@ -53,7 +53,11 @@ proot-distro login ubuntu     # 登录Ubuntu
 
 ```bash
 apt update
-apt install sudo vim git python3-dev python3.12-venv build-essential screen curl python3-pip
+apt upgrade #推荐升级最新版本包，也可不升级
+```
+
+```bash
+apt install sudo vim git python3-dev python3-venv build-essential screen curl python3-pip
 ```
 
 ### 用户账户配置 (可选但推荐)


### PR DESCRIPTION

![IMG_20260404_023303](https://github.com/user-attachments/assets/4727e7ea-c47b-4a0b-b206-1fc8d4f18f03)
![IMG_20260404_023311](https://github.com/user-attachments/assets/3657af16-3627-4bf2-acd3-b8627242059a)
解决了原本第56条无法定位软件包和匹配python3.12-venv问题
给原本第55条apt update做了可选择升级的建议