### PR TITLE
  docs(docker): 添加独立版 docker-compose 命令报错的常见问题排查

### DIFF
--- a/manual/deployment/docker.md
+++ b/manual/deployment/docker.md
@@ -202,3 +202,11 @@ docker compose down
 ```bash
 docker compose restart
 ```
+
+### 输入命令报错 `unknown shorthand flag: 'd' in -d`？
+
+说明你的服务器安装的是**独立版（Standalone）**的 Docker Compose。请将命令中间的空格替换为**短横线**执行：
+```bash
+docker-compose up -d
+```
+同理，本文档后续所有形如 docker compose <命令> 的操作，在你的服务器上都需要写成 docker-compose <命令>（例如 docker-compose restart core）


### PR DESCRIPTION
补充说明：部分使用宝塔面板或旧版 Linux 的用户，默认安装的是独立版的 docker-compose。他们在按文档执行带空格的 docker compose 命令时，会遇到 unknown shorthand flag: 'd' in -d 的报错。因此在常见问题中补充了相应的排查和解决办法，降低新手入门门槛。